### PR TITLE
feat: iOS 앱의 홈 페이지 구성

### DIFF
--- a/ios/how-is-outside/how-is-outside.xcodeproj/project.pbxproj
+++ b/ios/how-is-outside/how-is-outside.xcodeproj/project.pbxproj
@@ -1,0 +1,329 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		C0AC5A082D1FA35B00084F3A /* how-is-outside.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "how-is-outside.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C0AC5A0A2D1FA35B00084F3A /* how-is-outside */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "how-is-outside";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C0AC5A052D1FA35B00084F3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C0AC59FF2D1FA35B00084F3A = {
+			isa = PBXGroup;
+			children = (
+				C0AC5A0A2D1FA35B00084F3A /* how-is-outside */,
+				C0AC5A092D1FA35B00084F3A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C0AC5A092D1FA35B00084F3A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C0AC5A082D1FA35B00084F3A /* how-is-outside.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C0AC5A072D1FA35B00084F3A /* how-is-outside */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0AC5A162D1FA35D00084F3A /* Build configuration list for PBXNativeTarget "how-is-outside" */;
+			buildPhases = (
+				C0AC5A042D1FA35B00084F3A /* Sources */,
+				C0AC5A052D1FA35B00084F3A /* Frameworks */,
+				C0AC5A062D1FA35B00084F3A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C0AC5A0A2D1FA35B00084F3A /* how-is-outside */,
+			);
+			name = "how-is-outside";
+			packageProductDependencies = (
+			);
+			productName = "how-is-outside";
+			productReference = C0AC5A082D1FA35B00084F3A /* how-is-outside.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C0AC5A002D1FA35B00084F3A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					C0AC5A072D1FA35B00084F3A = {
+						CreatedOnToolsVersion = 16.2;
+					};
+				};
+			};
+			buildConfigurationList = C0AC5A032D1FA35B00084F3A /* Build configuration list for PBXProject "how-is-outside" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C0AC59FF2D1FA35B00084F3A;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = C0AC5A092D1FA35B00084F3A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C0AC5A072D1FA35B00084F3A /* how-is-outside */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C0AC5A062D1FA35B00084F3A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C0AC5A042D1FA35B00084F3A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C0AC5A142D1FA35D00084F3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C0AC5A152D1FA35D00084F3A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C0AC5A172D1FA35D00084F3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"how-is-outside/Preview Content\"";
+				DEVELOPMENT_TEAM = E2VVE99AF3;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "AHEAD94.how-is-outside";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C0AC5A182D1FA35D00084F3A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"how-is-outside/Preview Content\"";
+				DEVELOPMENT_TEAM = E2VVE99AF3;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "AHEAD94.how-is-outside";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C0AC5A032D1FA35B00084F3A /* Build configuration list for PBXProject "how-is-outside" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0AC5A142D1FA35D00084F3A /* Debug */,
+				C0AC5A152D1FA35D00084F3A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C0AC5A162D1FA35D00084F3A /* Build configuration list for PBXNativeTarget "how-is-outside" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0AC5A172D1FA35D00084F3A /* Debug */,
+				C0AC5A182D1FA35D00084F3A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C0AC5A002D1FA35B00084F3A /* Project object */;
+}

--- a/ios/how-is-outside/how-is-outside.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/how-is-outside/how-is-outside.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/how-is-outside/how-is-outside.xcodeproj/xcuserdata/ahead.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios/how-is-outside/how-is-outside.xcodeproj/xcuserdata/ahead.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>how-is-outside.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios/how-is-outside/how-is-outside/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/how-is-outside/how-is-outside/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/how-is-outside/how-is-outside/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/how-is-outside/how-is-outside/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/how-is-outside/how-is-outside/Assets.xcassets/Contents.json
+++ b/ios/how-is-outside/how-is-outside/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/how-is-outside/how-is-outside/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/how-is-outside/how-is-outside/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/how-is-outside/how-is-outside/Views/ContentView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/ContentView.swift
@@ -1,0 +1,36 @@
+//
+//  ContentView.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var selection: Tab = .home
+    
+    enum Tab {
+        case home
+        case history
+    }
+    
+    var body: some View {
+        TabView(selection: $selection) {
+            HomePage()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+                .tag(Tab.home)
+            HistoryList()
+                .tabItem {
+                    Label("History", systemImage: "clock.fill")
+                }
+                .tag(Tab.history)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
@@ -1,0 +1,18 @@
+//
+//  HistoryList.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct HistoryList: View {
+    var body: some View {
+        Text("과거날씨 - 체감지수 매핑정보 리스트")
+    }
+}
+
+#Preview {
+    HistoryList()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Home/HomePage.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/HomePage.swift
@@ -1,0 +1,54 @@
+//
+//  HomePage.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct HomePage: View {
+    var body: some View {
+        ScrollView {
+            VStack {
+                HStack {
+                    Text("밖에 어때")
+                        .font(.system(.largeTitle, weight: .bold))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 8)
+                    Text("날씨 체감 Insight")
+                        .font(.system(.body, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                
+                // 현재 날씨
+                WeatherView()
+                
+                // 상태바
+                StatusBarView()
+                
+                // 비슷한 과거 의복 & 내 옷장
+                HStack {
+                    PastWeatherView()
+                    MyClosetView()
+                }
+                
+                // 앱 정보
+                VStack {
+                    Text("날씨 체감 Insight")
+                    Text("밖에 어때, How is Outside")
+                }
+                .font(.system(.caption, weight: .regular))
+                .foregroundStyle(.secondary)
+                .padding(.top, 30)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+}
+
+#Preview {
+    HomePage()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Home/MyClosetView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/MyClosetView.swift
@@ -1,0 +1,29 @@
+//
+//  MyClosetView.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct MyClosetView: View {
+    var body: some View {
+        VStack {
+            Text("[ 내 옷장 ]")
+                .font(.headline)
+                .padding(.bottom, 1)
+            Text("추천: 얇은 셔츠, 반바지")
+                .font(.subheadline)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 200)
+        .padding()
+        .background(Color.purple.opacity(0.7))
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    MyClosetView()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Home/PastWeatherView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/PastWeatherView.swift
@@ -1,0 +1,42 @@
+//
+//  PastWeatherView.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct PastWeatherView: View {
+    var body: some View {
+        VStack {
+            Text("[ 더웠던 날 ]")
+                .font(.headline)
+                .padding(.bottom, 1)
+            Text("2023년 8월 15일")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+            Text("맑음, 25°C")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+            
+            // 착장 정보는 착용한 의복만 보이도록 구현
+            Text("착장 정보")
+                .font(.headline)
+                .padding(.top, 1)
+            Text("상의 : 반팔티")
+                .font(.subheadline)
+            Text("하의 : 청바지")
+                .font(.subheadline)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 200)
+        .padding()
+        .background(Color.orange.opacity(0.7))
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    PastWeatherView()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Home/StatusBarView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/StatusBarView.swift
@@ -1,0 +1,28 @@
+//
+//  StatusBarView.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct StatusBarView: View {
+    var body: some View {
+        HStack {
+            Text("[적절]")
+                .font(.headline)
+            Text("다음 3시간동안 비슷한 정도를 유지해요")
+                .font(.subheadline)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .frame(height: 50)
+        .background(Color.green.opacity(0.7))
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    StatusBarView()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Home/WeatherView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/WeatherView.swift
@@ -1,0 +1,29 @@
+//
+//  WeatherView.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+struct WeatherView: View {
+    var body: some View {
+        VStack {
+            Text("종일 날씨")
+                .font(.largeTitle)
+                .bold()
+            Text("맑음, 25°C")
+                .font(.title2)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 320)
+        .padding()
+        .background(Color.blue.opacity(0.7))
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    WeatherView()
+}

--- a/ios/how-is-outside/how-is-outside/how_is_outsideApp.swift
+++ b/ios/how-is-outside/how-is-outside/how_is_outsideApp.swift
@@ -1,0 +1,17 @@
+//
+//  how_is_outsideApp.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 12/28/24.
+//
+
+import SwiftUI
+
+@main
+struct how_is_outsideApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
Closes #1 

- 종일 날씨를 보여주는 뷰 배치
- 이후 날씨를 요약해주는 상태바 배치
- 비슷했던 이전 날씨의 의복과 체감지수를 보여주는 뷰 배치
- 내가 가진 옷을 나타내는 옷장 뷰 배치

![image](https://github.com/user-attachments/assets/d5770bd2-dc84-4493-84f2-a21d5476ed5a)
