### PR TITLE
fix: WeatherView의 날씨 업데이트 문제 해결

### DIFF
--- a/ios/how-is-outside/how-is-outside/Views/Home/WeatherView.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Home/WeatherView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct WeatherView: View {
-    @StateObject private var viewModel = WeatherViewModel()
+    // HomePage의 viewModel을 전달받아 사용
+    @ObservedObject var viewModel = WeatherViewModel()
     
     var body: some View {
         VStack(spacing: 7) {


### PR DESCRIPTION
Close #23 

- 상위 뷰인 HomePage에서 생성한 viewModel을 하위 뷰 WeatherView에서 전달받아 공유하도록 수정
  - WeatherView에서 @StateObject로 선언된 viewModel을 @ObservedObject로 변경