### PR TITLE
feat: 서버 요청 기반 DB 체감정보 페이지 추가

### DIFF
--- a/ios/how-is-outside/how-is-outside/Views/Helpers/FeedbackDataIcons.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Helpers/FeedbackDataIcons.swift
@@ -1,0 +1,36 @@
+//
+//  FeedbackDataIcons.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 1/4/25.
+//
+
+import SwiftUI
+
+struct FeedbackDataIcons: View {
+    var body: some View {
+        HStack {
+            Spacer(minLength: 7)
+            Image(systemName: "person.and.background.striped.horizontal")
+                .frame(maxWidth: .infinity)
+            Spacer()
+            Image(systemName: "cloud.sun.fill")
+                .frame(maxWidth: .infinity)
+            Spacer()
+            Image(systemName: "thermometer.medium")
+                .frame(maxWidth: .infinity)
+            Spacer()
+            Image(systemName: "humidity.fill")
+                .frame(maxWidth: .infinity)
+            Spacer()
+            Image(systemName: "wind")
+                .frame(maxWidth: .infinity)
+            Spacer(minLength: 25)
+        }
+        .padding(12)
+    }
+}
+
+#Preview {
+    FeedbackDataIcons()
+}

--- a/ios/how-is-outside/how-is-outside/Views/Helpers/ServerButton.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Helpers/ServerButton.swift
@@ -1,0 +1,22 @@
+//
+//  ServerButton.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 1/4/25.
+//
+
+import SwiftUI
+
+struct ServerButton: View {
+    var body: some View {
+        NavigationLink(destination: ServerHistoryList()) {
+            Image(systemName: "externaldrive.badge.icloud")
+                .font(.system(size: 25))
+                .padding(.horizontal)
+        }
+    }
+}
+
+#Preview {
+    ServerButton()
+}

--- a/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
@@ -11,33 +11,21 @@ struct HistoryList: View {
     @StateObject private var modelData = FeedbackModelData.shared
     
     var body: some View {
-        NavigationSplitView {
+        NavigationStack {
             VStack {
-                Text("체감 정보")
-                    .font(.system(.largeTitle, weight: .bold))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
-                    .padding(.bottom, 8)
-                
                 HStack {
-                    Spacer(minLength: 7)
-                    Image(systemName: "person.and.background.striped.horizontal")
-                        .frame(maxWidth: .infinity)
+                    Text("체감 정보")
+                        .font(.system(.largeTitle, weight: .bold))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal)
+                        .padding(.bottom, 8)
+                    
                     Spacer()
-                    Image(systemName: "cloud.sun.fill")
-                        .frame(maxWidth: .infinity)
-                    Spacer()
-                    Image(systemName: "thermometer.medium")
-                        .frame(maxWidth: .infinity)
-                    Spacer()
-                    Image(systemName: "humidity.fill")
-                        .frame(maxWidth: .infinity)
-                    Spacer()
-                    Image(systemName: "wind")
-                        .frame(maxWidth: .infinity)
-                    Spacer(minLength: 25)
+                    
+                    ServerButton()
                 }
-                .padding(12)
+                
+                FeedbackDataIcons()
                 
                 List {
                     ForEach(modelData.feedbacks) { feedback in
@@ -51,8 +39,6 @@ struct HistoryList: View {
                 .listStyle(.plain)
                 .animation(.default, value: modelData.feedbacks)
             }
-        } detail: {
-            Text("체감 정보 선택")
         }
     }
 }

--- a/ios/how-is-outside/how-is-outside/Views/History/HistoryRow.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/HistoryRow.swift
@@ -15,10 +15,13 @@ struct HistoryRow: View {
             Text(feedback.user_rating)
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
+                .padding(.vertical, 8)
             Spacer()
             Text(feedback.description)
                 .frame(maxWidth: .infinity)
-                .lineLimit(1)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.1)
             Spacer()
             Text(feedback.temperature)
                 .frame(maxWidth: .infinity)
@@ -32,7 +35,6 @@ struct HistoryRow: View {
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
         }
-        .padding(.vertical, 7)
     }
 }
 
@@ -41,6 +43,6 @@ struct HistoryRow: View {
     return Group {
         HistoryRow(feedback: feedbacks[0])
         HistoryRow(feedback: feedbacks[1])
-        HistoryRow(feedback: feedbacks[2])
+        HistoryRow(feedback: feedbacks[13])
     }
 }

--- a/ios/how-is-outside/how-is-outside/Views/History/ServerHistoryList.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/ServerHistoryList.swift
@@ -1,0 +1,71 @@
+//
+//  ServerHistoryList.swift
+//  how-is-outside
+//
+//  Created by Ryu Dae-ha on 1/4/25.
+//
+
+import SwiftUI
+
+struct ServerHistoryList: View {
+    @State private var feedbackList: [Feedback] = [] // 서버 데이터를 저장할 배열
+    @State private var isLoading = true             // 로딩 상태 표시
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text("서버 등록 내역")
+                    .font(.system(.title3, weight: .bold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
+            }
+            
+            FeedbackDataIcons()
+            
+            if isLoading {
+                ProgressView("Loading...") // 로딩 상태 표시
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(maxHeight: .infinity, alignment: .center)
+                    .padding(.bottom, 30)
+            } else if feedbackList.isEmpty {
+                Text("불러온 데이터가 없습니다.")
+                    .font(.headline)
+                    .foregroundColor(.gray)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(maxHeight: .infinity, alignment: .center)
+                    .padding(.bottom, 30)
+            } else {
+                List {
+                    ForEach(feedbackList) { feedback in
+                        NavigationLink {
+                            FeedbackDetail()
+                        } label: {
+                            HistoryRow(feedback: feedback)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .animation(.default, value: feedbackList)
+            }
+        }
+        .onAppear {
+            loadFeedbackData() // 뷰가 나타날 때 데이터 로드
+        }
+    }
+    
+    // 서버에서 데이터를 가져와 배열에 저장
+    private func loadFeedbackData() {
+        fetchWeatherFeedback { feedbackArray in
+            DispatchQueue.main.async {
+                self.feedbackList = feedbackArray
+                self.isLoading = false
+            }
+        }
+    }
+}
+
+#Preview {
+    ServerHistoryList()
+}


### PR DESCRIPTION
Close #32 

- HistoryList 뷰에서 서버 데이터 페이지로 이동하는 버튼 구현
- 서버에 체감정보 데이터를 요청하여 페이지에 리스트 형태로 보여지도록 구현
- 리스트에 간단한 날씨 정보와 사용자 체감정보를 표시하도록 구현

기타 변경사항

- 체감정보 리스트에 보이는 텍스트가 길어지면 생략되는 현상 수정
- 리스트의 행 간격을 조절