### PR TITLE
feat: 날씨 체감정보를 로컬에서 삭제하는 기능 구현

### DIFF
--- a/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/HistoryList.swift
@@ -35,11 +35,17 @@ struct HistoryList: View {
                             HistoryRow(feedback: feedback)
                         }
                     }
+                    .onDelete(perform: deleteFeedback)
                 }
                 .listStyle(.plain)
                 .animation(.default, value: modelData.feedbacks)
             }
         }
+    }
+    
+    private func deleteFeedback(at offsets: IndexSet) {
+        modelData.feedbacks.remove(atOffsets: offsets)
+        modelData.saveFeedbacks() // 로컬 데이터 업데이트
     }
 }
 


### PR DESCRIPTION
Close #36 

- 사용자가 등록한 날씨 체감정보를 기기에서 삭제하는 기능 추가
- HistoryList 페이지에서 특정 데이터를 왼쪽으로 밀어 삭제하도록 구현