### PR TITLE
feat: 체감정보 리스트 정보에 날짜와 시간 추가

### DIFF
--- a/ios/how-is-outside/how-is-outside/Views/Helpers/FeedbackDataIcons.swift
+++ b/ios/how-is-outside/how-is-outside/Views/Helpers/FeedbackDataIcons.swift
@@ -11,6 +11,9 @@ struct FeedbackDataIcons: View {
     var body: some View {
         HStack {
             Spacer(minLength: 7)
+            Image(systemName: "calendar.badge.clock")
+                .frame(maxWidth: .infinity)
+            Spacer()
             Image(systemName: "person.and.background.striped.horizontal")
                 .frame(maxWidth: .infinity)
             Spacer()

--- a/ios/how-is-outside/how-is-outside/Views/History/HistoryRow.swift
+++ b/ios/how-is-outside/how-is-outside/Views/History/HistoryRow.swift
@@ -12,28 +12,39 @@ struct HistoryRow: View {
     
     var body: some View {
         HStack {
+            VStack {
+                Text(feedback.date)
+                Text(feedback.time)
+            }
+            .frame(maxWidth: .infinity)
+            .lineLimit(1)
+            .minimumScaleFactor(0.1)
+            Spacer()
             Text(feedback.user_rating)
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
+                .minimumScaleFactor(0.1)
                 .padding(.vertical, 8)
             Spacer()
             Text(feedback.description)
                 .frame(maxWidth: .infinity)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
+                .lineLimit(1)
                 .minimumScaleFactor(0.1)
             Spacer()
             Text(feedback.temperature)
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
+                .minimumScaleFactor(0.1)
             Spacer()
             Text(feedback.humidity)
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
+                .minimumScaleFactor(0.1)
             Spacer()
             Text(feedback.wind)
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
+                .minimumScaleFactor(0.1)
         }
     }
 }
@@ -43,6 +54,5 @@ struct HistoryRow: View {
     return Group {
         HistoryRow(feedback: feedbacks[0])
         HistoryRow(feedback: feedbacks[1])
-        HistoryRow(feedback: feedbacks[13])
     }
 }


### PR DESCRIPTION
Close #38 

- 사용자 체감정보 리스트의 정보에 날짜와 시간을 추가
- 체감정보 리스트의 정보를 구분하는 열 아이콘에 날짜 및 시간을 나타내는 아이콘 추가
- 체감정보 리스트의 정보와 아이콘들 간의 간격과 최소 글자 크기를 조절