### PR TITLE
refactor: HomePage 하위 뷰에서 뷰모델을 공유하도록 수정

### DIFF
--- a/ios/your-weather/your-weather/Views/Home/WeatherDetailView.swift
+++ b/ios/your-weather/your-weather/Views/Home/WeatherDetailView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct WeatherDetailView: View {
     // HomePage의 viewModel을 전달받아 사용
-    @ObservedObject var viewModel = WeatherViewModel()
+    @EnvironmentObject var viewModel: WeatherViewModel
     
     var body: some View {
         VStack(spacing: 7) {
@@ -30,4 +30,5 @@ struct WeatherDetailView: View {
 
 #Preview {
     WeatherDetailView()
+        .environmentObject(WeatherViewModel())
 }

--- a/ios/your-weather/your-weather/Views/Home/WeatherView.swift
+++ b/ios/your-weather/your-weather/Views/Home/WeatherView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct WeatherView: View {
     // HomePage의 viewModel을 전달받아 사용
-    @ObservedObject var viewModel = WeatherViewModel()
+    @EnvironmentObject var viewModel: WeatherViewModel
     
     var body: some View {
         VStack(spacing: 7) {
@@ -36,4 +36,5 @@ struct WeatherView: View {
 
 #Preview {
     WeatherView()
+        .environmentObject(WeatherViewModel())
 }


### PR DESCRIPTION
Closes #71

- Hompage 뷰에서 StateObject로 선언된 뷰모델을 하위 뷰에서 EnvironmentObject로 받아서 공유할 수 있도록 수정