### PR TITLE
fix: WeatherSaveView의 Preview에 뷰모델 전달

### DIFF
--- a/ios/your-weather/your-weather/Views/Management/WeatherSaveView.swift
+++ b/ios/your-weather/your-weather/Views/Management/WeatherSaveView.swift
@@ -115,4 +115,5 @@ struct WeatherSaveView: View {
 
 #Preview {
     WeatherSaveView()
+        .environmentObject(WeatherViewModel())
 }


### PR DESCRIPTION
Closes #72 

- WeatherSaveView의 Preview에 WeatherViewModel을 environmentObject로 전달