### PR TITLE
refactor: 날씨와 피드백 데이터를 로컬에 저장하는 로직 수정

### DIFF
--- a/ios/your-weather/your-weather/ViewModels/LocalFeedbackViewModel.swift
+++ b/ios/your-weather/your-weather/ViewModels/LocalFeedbackViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 class LocalFeedbackViewModel: ObservableObject {
     @Published var feedbacks: [Feedback] = []
     
-    private let storageManager = FeedbackStorageManager()
+    private let storageManager = FeedbackStorageManager.shared
     
     init() {
         loadFeedbacks()


### PR DESCRIPTION
Closes #69

- 날씨제공 API로부터의 날씨와 사용자의 피드백의 초기 JSON 파일 생성
- WeatherDataManager와 FeedbackStorageManager의 싱글톤 패턴 적용 및 일관화